### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -5,6 +5,7 @@ class ProductsController < ApplicationController
   end
 
   def show
+    @product = Product.find(params[:id])
   end
 
   def new
@@ -24,6 +25,6 @@ class ProductsController < ApplicationController
 
   def product_params
     params.require(:product).permit(:image, :item, :description, :category_id, :status_id, :price,
-                                    :delivery_cost_id, :shipping_area_id, :how_many_days_id).merge(user_id: current_user.id)
+                                    :delivery_cost_id, :shipping_area_id, :how_many_day_id).merge(user_id: current_user.id)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,13 +3,18 @@ class Product < ApplicationRecord
   has_one_attached :image
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :delivery_cost
+  belongs_to :category
+  belongs_to :shipping_area
+  belongs_to :how_many_day
+  belongs_to :status
+  
 
   with_options numericality: { other_than: 1, message: "can not be blank" } do
     validates :category_id 
     validates :status_id
     validates :delivery_cost_id
     validates :shipping_area_id
-    validates :how_many_days_id
+    validates :how_many_day_id
   end
   validates :price, format: { with: /\A[0-9]+\z/ },
                     numericality: {

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -151,7 +151,7 @@
         <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <% @products.each do |product|%>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to product_path(product.id) do %>
             <div class='item-img-content'>
               <%= image_tag product.image, class: "item-img" %>
 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -79,7 +79,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:how_many_days_id, HowManyDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:how_many_day_id, HowManyDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -24,13 +24,16 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% if user_signed_in? && current_user.id == @product.user_id%>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%# 出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること%>
+    <% if user_signed_in? %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -24,19 +24,13 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if user_signed_in? && current_user.id == @product.user_id%>
+    <% if user_signed_in? && current_user.id == @product.user_id %>
       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% end %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%# 出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること%>
-    <% if user_signed_in? && current_user.id =! @product.user_id%>
+    <% else %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
@@ -105,7 +99,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @product.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -31,7 +31,7 @@
     <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%# 出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること%>
-    <% if user_signed_in? %>
+    <% if user_signed_in? && current_user.id =! @product.user_id%>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
@@ -46,7 +46,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @product.user.firstname %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,22 +4,22 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.item %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @product.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%# div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @product.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @product.delivery_cost.name %>
       </span>
     </div>
 
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.firstname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.delivery_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.how_many_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -24,12 +24,15 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if user_signed_in? && current_user.id == @product.user_id %>
-      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-      <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% else %>
-      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%# if ログインしているユーザーと出品しているユーザーが、同一人物の場合 %>
+    <% if user_signed_in? %>
+      <% if current_user.id == @product.user_id%>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% else %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
     <% end%>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 

--- a/db/migrate/20201105122242_create_products.rb
+++ b/db/migrate/20201105122242_create_products.rb
@@ -8,7 +8,7 @@ class CreateProducts < ActiveRecord::Migration[6.0]
       t.integer      :price,             null: false
       t.integer      :delivery_cost_id,  null: false
       t.integer      :shipping_area_id,  null: false
-      t.integer      :how_many_days_id,  null: false
+      t.integer      :how_many_day_id,  null: false
       t.references   :user,              null: false, foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 2020_11_05_130904) do
     t.integer "price", null: false
     t.integer "delivery_cost_id", null: false
     t.integer "shipping_area_id", null: false
-    t.integer "how_many_days_id", null: false
+    t.integer "how_many_day_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -8,7 +8,7 @@ describe Product do
   describe '商品出品' do
     context '商品出品がうまくいくとき' do
       it 'item, description, category_id, status_id, price,
-      delivery_cost_id, shipping_area_id, how_many_days_idとimageが存在すれば登録できる' do
+      delivery_cost_id, shipping_area_id, how_many_day_idとimageが存在すれば登録できる' do
         expect(@product).to be_valid
       end
     end
@@ -49,9 +49,9 @@ describe Product do
         expect(@product.errors.full_messages).to include("Shipping area can not be blank")
       end
       it "発送までの日数についての情報が必須であること" do
-        @product.how_many_days_id = 1
+        @product.how_many_day_id = 1
         @product.valid?
-        expect(@product.errors.full_messages).to include("How many days can not be blank")
+        expect(@product.errors.full_messages).to include("How many day can not be blank")
       end
       it "価格についての情報が必須であること" do
         @product.price = nil


### PR DESCRIPTION
### What
商品詳細表示機能の実装

### Why
- ログアウト状態でも商品詳細ページを閲覧できること
- 出品者にしか商品の編集・削除のリンクが踏めないようになっていること
- 出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
- 商品出品時に登録した情報が見られるようになっていること

機能のキャプチャ
- ログアウト状態でも商品詳細ページを閲覧できること
- 出品者にしか商品の編集・削除のリンクが踏めないようになっていること
- 出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
- 商品出品時に登録した情報が見られるようになっていること
https://gyazo.com/1c76dae21dab9e4459feb0a677ca2ae7

- 出品者が商品の編集・削除のリンクがアクセスできること
- 出品者が自分の商品が買わないこと
https://gyazo.com/642b47ce92bb3300761a7029e5dbc53e





