### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'sass-rails', '~> 5'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 4.0'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+#gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,9 +248,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -303,7 +300,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
   webdrivers

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -25,10 +25,11 @@ class ProductsController < ApplicationController
   end
 
   def update
-    product = Product.find(params[:id])
-    if product.update(product_params)
+    @product = Product.find(params[:id])
+    if @product.update(product_params)
       redirect_to product_path
     else
+      @product.update(product_params)
       render :edit
     end
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -26,7 +26,11 @@ class ProductsController < ApplicationController
 
   def update
     product = Product.find(params[:id])
-    product.update(product_params)
+    if product.update(product_params)
+      redirect_to product_path
+    else
+      render :edit
+    end
   end
 
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,6 @@
 class ProductsController < ApplicationController
   before_action :find_params, only: [:edit, :show]
-  before_action :move_to_index, except: [:index, :show, :update]
-  #before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:index, :show, :update]
 
   def index
     @products = Product.order('created_at DESC')
@@ -50,7 +49,4 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
-  def move_to_index
-    authenticate_user!
-  end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < ApplicationController
   before_action :find_params, only: [:edit, :show]
   before_action :move_to_index, except: [:index, :show, :update]
+  #before_action :authenticate_user!
 
   def index
     @products = Product.order('created_at DESC')
@@ -24,7 +25,9 @@ class ProductsController < ApplicationController
   end
 
   def edit
-
+    unless current_user.id == @product.user_id
+      redirect_to action: :index
+    end
   end
 
   def update
@@ -48,8 +51,6 @@ class ProductsController < ApplicationController
   end
 
   def move_to_index
-    unless user_signed_in?
-      redirect_to action: :index
-    end
+    authenticate_user!
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -20,6 +20,14 @@ class ProductsController < ApplicationController
     end
   end
 
+  def edit
+    @product = Product.find(params[:id])
+  end
+
+  def update
+  end
+  
+
   private
 
   def product_params

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -31,7 +31,6 @@ class ProductsController < ApplicationController
     if @product.update(product_params)
       redirect_to product_path
     else
-      @product.update(product_params)
       render :edit
     end
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -25,8 +25,10 @@ class ProductsController < ApplicationController
   end
 
   def update
+    product = Product.find(params[:id])
+    product.update(product_params)
   end
-  
+
 
   private
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   before_action :find_params, only: [:edit, :show]
-  before_action :move_to_index, except: [:index, :show]
+  before_action :move_to_index, except: [:index, :show, :update]
 
   def index
     @products = Product.order('created_at DESC')
@@ -28,7 +28,6 @@ class ProductsController < ApplicationController
   end
 
   def update
-    @product = Product.find(params[:id])
     if @product.update(product_params)
       redirect_to product_path
     else

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,6 @@
 class ProductsController < ApplicationController
   def index
-    @products = Product.order("created_at DESC")
-    
+    @products = Product.order('created_at DESC')
   end
 
   def show

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,10 +1,12 @@
 class ProductsController < ApplicationController
+  before_action :find_params, only: [:edit, :show]
+
   def index
     @products = Product.order('created_at DESC')
   end
 
   def show
-    @product = Product.find(params[:id])
+    
   end
 
   def new
@@ -21,7 +23,7 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    @product = Product.find(params[:id])
+    
   end
 
   def update
@@ -40,5 +42,9 @@ class ProductsController < ApplicationController
   def product_params
     params.require(:product).permit(:image, :item, :description, :category_id, :status_id, :price,
                                     :delivery_cost_id, :shipping_area_id, :how_many_day_id).merge(user_id: current_user.id)
+  end
+
+  def find_params
+    @product = Product.find(params[:id])
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,6 @@
 class ProductsController < ApplicationController
   before_action :find_params, only: [:edit, :show]
+  before_action :move_to_index, except: [:index, :show]
 
   def index
     @products = Product.order('created_at DESC')
@@ -23,7 +24,7 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    
+
   end
 
   def update
@@ -45,5 +46,11 @@ class ProductsController < ApplicationController
 
   def find_params
     @product = Product.find(params[:id])
+  end
+
+  def move_to_index
+    unless user_signed_in?
+      redirect_to action: :index
+    end
   end
 end

--- a/app/javascript/calculate.js
+++ b/app/javascript/calculate.js
@@ -1,7 +1,7 @@
 function calculate() {
   const priceInput = document.getElementById("item-price")
   //入力する時、下記のアクションを発火させる
-  priceInput.addEventListener("input", doCalculate);
+  priceInput.addEventListener("keyup", doCalculate);
   
   function doCalculate() {
     // 値の取得

--- a/app/javascript/calculate.js
+++ b/app/javascript/calculate.js
@@ -1,7 +1,9 @@
 function calculate() {
   const priceInput = document.getElementById("item-price")
   //入力する時、下記のアクションを発火させる
-  priceInput.addEventListener( "input", function() {
+  priceInput.addEventListener("input", doCalculate);
+  
+  function doCalculate() {
     // 値の取得
     var numData = document.getElementById("item-price").value;
     // 手数料の計算
@@ -14,7 +16,7 @@ function calculate() {
     //HTMLに入力させる
     document.getElementById("add-tax-price").innerHTML = numTax;
     document.getElementById("profit").innerHTML = numProfit;
-  }) 
+    }
 
   function dataFormatPrice(numTax) {
     var data = "";

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("../calculate")

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -24,5 +24,12 @@ class Product < ApplicationRecord
     validates :image
     validates :item
     validates :description
+    validates :category
+    validates :status_id
+    validates :price
+    validates :delivery_cost
+    validates :shipping_area
+    validates :how_many_day
   end
 end
+

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,10 +7,9 @@ class Product < ApplicationRecord
   belongs_to :shipping_area
   belongs_to :how_many_day
   belongs_to :status
-  
 
-  with_options numericality: { other_than: 1, message: "can not be blank" } do
-    validates :category_id 
+  with_options numericality: { other_than: 1, message: 'can not be blank' } do
+    validates :category_id
     validates :status_id
     validates :delivery_cost_id
     validates :shipping_area_id
@@ -19,7 +18,7 @@ class Product < ApplicationRecord
   validates :price, format: { with: /\A[0-9]+\z/ },
                     numericality: {
                       greater_than_or_equal_to: 300,
-                      less_than_or_equal_to: 9999999
+                      less_than_or_equal_to: 9_999_999
                     }
   with_options presence: true do
     validates :image

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -3,11 +3,11 @@ app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), root_path %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @product , url: products_path,local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :item, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_cost_id, DeliveryCost.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:shipping_area_id, ShippingArea.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:how_many_day_id, HowManyDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -10,7 +10,7 @@ app/assets/stylesheets/items/new.css %>
     <%= form_with model: @product, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -141,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', product_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @product , url: products_path,local: true do |f| %>
+    <%= form_with model: @product, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -27,7 +27,7 @@
     <%# if ログインしているユーザーと出品しているユーザーが、同一人物の場合 %>
     <% if user_signed_in? %>
       <% if current_user.id == @product.user_id%>
-        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <%= link_to '商品の編集', edit_product_path, method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
       <% else %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -15,7 +15,7 @@
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
-      <span class="item-price">
+      <span class="item-price">¥
         <%= @product.price %>
       </span>
       <span class="item-postage">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -27,7 +27,7 @@
     <%# if ログインしているユーザーと出品しているユーザーが、同一人物の場合 %>
     <% if user_signed_in? %>
       <% if current_user.id == @product.user_id%>
-        <%= link_to '商品の編集', edit_product_path, method: :get, class: "item-red-btn" %>
+        <%= link_to '商品の編集', edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to: "products#index"
   
   resources :users
-  resources :products, only: [:index, :new, :create, :show]
+  resources :products
   
 
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -4,14 +4,14 @@ FactoryBot.define do
     description          { 'ラインがきれいに見えるタートルネック' }
     category_id          { 2 }
     status_id            { 2 }
-    price                { 345454 }
+    price                { 345_454 }
     delivery_cost_id     { 3 }
     shipping_area_id     { 3 }
     how_many_days_id     { 3 }
 
-    association :user 
+    association :user
 
-    #テスト用のダミー画像を用意
+    # テスト用のダミー画像を用意
     after(:build) do |item|
       item.image.attach(io: File.open('app/assets/images/camera.png'), filename: 'camera.png')
     end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -13,68 +13,67 @@ describe Product do
       end
     end
     context '商品出品がうまくいくとき' do
-      it "画像は1枚必須であること" do
+      it '画像は1枚必須であること' do
         @product.image = nil
         @product.valid?
         expect(@product.errors.full_messages).to include("Image can't be blank")
       end
-      it "商品名が必須であること" do
+      it '商品名が必須であること' do
         @product.item = nil
         @product.valid?
         expect(@product.errors.full_messages).to include("Item can't be blank")
       end
-      it "商品説明が必須であること" do
+      it '商品説明が必須であること' do
         @product.description = nil
         @product.valid?
         expect(@product.errors.full_messages).to include("Description can't be blank")
       end
-      it "カテゴリーの情報が必須であること" do
+      it 'カテゴリーの情報が必須であること' do
         @product.category_id = 1
         @product.valid?
-        expect(@product.errors.full_messages).to include("Category can not be blank")
+        expect(@product.errors.full_messages).to include('Category can not be blank')
       end
-      it "商品の状態についての情報が必須であること" do
+      it '商品の状態についての情報が必須であること' do
         @product.status_id = 1
         @product.valid?
-        expect(@product.errors.full_messages).to include("Status can not be blank")
+        expect(@product.errors.full_messages).to include('Status can not be blank')
       end
-      it "配送料の負担についての情報が必須であること" do
+      it '配送料の負担についての情報が必須であること' do
         @product.delivery_cost_id = 1
         @product.valid?
-        expect(@product.errors.full_messages).to include("Delivery cost can not be blank")
+        expect(@product.errors.full_messages).to include('Delivery cost can not be blank')
       end
-      it "発送元の地域についての情報が必須であること" do
+      it '発送元の地域についての情報が必須であること' do
         @product.shipping_area_id = 1
         @product.valid?
-        expect(@product.errors.full_messages).to include("Shipping area can not be blank")
+        expect(@product.errors.full_messages).to include('Shipping area can not be blank')
       end
-      it "発送までの日数についての情報が必須であること" do
+      it '発送までの日数についての情報が必須であること' do
         @product.how_many_day_id = 1
         @product.valid?
-        expect(@product.errors.full_messages).to include("How many day can not be blank")
+        expect(@product.errors.full_messages).to include('How many day can not be blank')
       end
-      it "価格についての情報が必須であること" do
+      it '価格についての情報が必須であること' do
         @product.price = nil
         @product.valid?
-        expect(@product.errors.full_messages).to include("Price is invalid")
+        expect(@product.errors.full_messages).to include('Price is invalid')
       end
-      it "価格が299円以下の場合は登録できない" do
+      it '価格が299円以下の場合は登録できない' do
         @product.price = 99
         @product.valid?
-        expect(@product.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@product.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
-      it "価格が10,000,000以上の場合は登録できない" do
-        @product.price = 10000000
+      it '価格が10,000,000以上の場合は登録できない' do
+        @product.price = 10_000_000
         @product.valid?
-        expect(@product.errors.full_messages).to include("Price must be less than or equal to 9999999")
+        expect(@product.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end
-      
-      it "販売価格は半角数字のみ保存可能であること" do
-        @product.price = "aaa"
+
+      it '販売価格は半角数字のみ保存可能であること' do
+        @product.price = 'aaa'
         @product.valid?
-        expect(@product.errors.full_messages).to include("Price is not a number")
+        expect(@product.errors.full_messages).to include('Price is not a number')
       end
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
### What
商品情報編集機能

### Why
商品情報編集機能を実装する

### 機能のキャプチャ動画
- 商品情報（商品画像・商品名・商品の状態など）を変更できること
- 出品者だけが編集ページに遷移できること
- 商品出品時とほぼ同じUIで編集機能が実装できること
https://gyazo.com/745abf01bbed33df01923f2101f21e64
- 何も編集せずに更新をしても画像無しの商品にならない
https://gyazo.com/c223b7af88ea8085074a349a40288a8e
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で表示されること（画像に関しては、表示されない状態で良い）
https://gyazo.com/bea51199fbc30b7df6c5f3c39da0605c
- エラーハンドリングができていること（適切では無い値が入力された場合、情報は保存されず、エラーメッセージを出力させる）
https://gyazo.com/e6ced6d3a1de46882451062065c56133
